### PR TITLE
Add Windows 64-bit cross-compilation support via MinGW-w64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ TAGS
 pkcs11.txt
 cert9.db
 key4.db
- 
+
+output-win64/

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Makefile.in
 *.deb
 *.tar.gz
 *.apk
+*.zip
 
 # from pkcs11-tools
 .pkcs11rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Added
+- support for Windows 64-bit cross-compilation via MinGW-w64 (`buildx/Dockerfile.mingw64`), integrated into the `buildx.sh` workflow (`./buildx.sh mingw64`). Produces both `.zip` and `.tar.gz` archives containing the shim DLL and its runtime DLLs.
+- `buildx.sh --local-source` option to build from the local workspace checkout instead of cloning the remote repository (submodules are resolved offline from the bind-mounted repo).
 
 ## [1.9.0] - 2025-03-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support for Windows 64-bit cross-compilation via MinGW-w64 (`buildx/Dockerfile.mingw64`), integrated into the `buildx.sh` workflow (`./buildx.sh mingw64`). Produces both `.zip` and `.tar.gz` archives containing the shim DLL and its runtime DLLs.
 - `buildx.sh --local-source` option to build from the local workspace checkout instead of cloning the remote repository (submodules are resolved offline from the bind-mounted repo).
 
+### Fixed
+- typo in the startup help banner: the description line read `PKS11SHIM_CONSISTENCY` (missing the `C` in `PKCS`) while the runtime echo and `getenv()` call already used the correct name `PKCS11SHIM_CONSISTENCY`.
+
 ## [1.9.0] - 2025-03-14
 ### Added
 - support for building the project - multiplatform builds using docker

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,51 @@
+# Installation
+
+## Using pre-built binaries
+Pre-built binaries are available for download from the release page. This is the simplest option, but you may be lacking the latest features.
+
+## Using Docker on Linux
+Provided that Docker is deployed on your system, you can build the library using the `buildx.sh` script, which is located in the root directory of the project. This script automates the process of building the library for various distributions and architectures. For each target platform, both a tarball and a distribution-specific package (`.deb`, `.rpm`, `.apk`) are built.
+
+To build the library using Docker for your architecture, you can use the following command (in this example, we are building for Ubuntu 24.04):
+```bash
+$ ./buildx.sh ubuntu2404
+```
+
+You can specify more than one target distribution at once, for example:
+```bash
+$ ./buildx.sh ol9 ubuntu2404 deb12
+```
+
+Provided that your environment supports multiple architectures (using `qemu`), you can cross-compile the library. For each target platform, you can specify the architecture. Note that `all` means to build for all available architectures, i.e. `x86_64` and `aarch64` in this occurence. For example:
+```bash
+$ ./buildx.sh ol9/amd64 ubuntu2404/arm64 deb12/all
+```
+
+`buildx.sh` supports parallel building, and comes with a number of options to specify the target distribution, the target architecture, the repository URL, the commit/tag/branch to build, and so on. You can see the help message by running:
+```bash
+$ ./buildx.sh --help
+```
+
+By default `buildx.sh` clones the repository from the remote URL. To build directly from your local checkout (including any committed local changes) without going through the network, use `--local-source`:
+```bash
+$ ./buildx.sh --local-source mingw64
+```
+
+### Supported distributions
+The following distributions are supported by the `buildx.sh` script:
+
+| Distribution | Distribution short name (to use with `buildx.sh`) |
+|--------------|---------------------------------------------------|
+| Oracle Linux 9 | `ol9` |
+| Oracle Linux 8 | `ol8` |
+| Oracle Linux 7 | `ol7` |
+| Debian 12 (Bookworm) | `deb12` |
+| Ubuntu 24.04 (Noble Numbat) | `ubuntu2404` |
+| Ubuntu 22.04 (Jammy Jellyfish) | `ubuntu2204` |
+| Alpine Linux 3.21 | `alpine321` |
+| Amazon Linux 2023 | `amzn2023` |
+| Windows 64-bit (MinGW-w64 cross-compile) | `mingw64` |
+
 ## Building from source (Linux)
 
 ### Prerequisites
@@ -37,30 +85,24 @@ make distclean
 make -j$(nproc)
 ```
 
-## Windows 64-bit (cross-compiling with Podman)
-
-The recommended way to build the Windows 64-bit DLL is using the provided Dockerfile with Podman:
-
-### Build
+## Windows 64-bit (cross-compiling with Docker)
+Windows 64-bit binaries are produced via MinGW-w64 cross-compilation, using the same `buildx.sh` workflow as the other supported distros. This requires Docker (Podman with a `docker` alias works as well):
 
 ```bash
-podman build -f buildx/Dockerfile.mingw64 -t libpkcs11shim-win64 .
+$ ./buildx.sh mingw64
 ```
 
-### Extract
+The build produces two archives in the current directory:
+- `libpkcs11shim-mingw64-x86_64-<version>.zip` (Windows-friendly format)
+- `libpkcs11shim-mingw64-x86_64-<version>.tar.gz`
 
-```bash
-podman create --name win64-extract --entrypoint /bin/true localhost/libpkcs11shim-win64
-mkdir -p output-win64
-podman cp win64-extract:/libpkcs11shim-0.dll ./output-win64/
-podman cp win64-extract:/libgcc_s_seh-1.dll ./output-win64/
-podman cp win64-extract:/libwinpthread-1.dll ./output-win64/
-podman rm win64-extract
-```
-
-The `output-win64/` directory will contain:
+Each archive contains the PKCS#11 shim DLL and its required runtime DLLs, along with the documentation:
 - `libpkcs11shim-0.dll` — the PKCS#11 shim library
 - `libwinpthread-1.dll` — pthreads runtime
 - `libgcc_s_seh-1.dll` — GCC runtime
 
-Copy the entire contents to your Windows machine to use.
+Extract the archive on your Windows machine to use the library.
+
+Notes:
+- Unlike the other distros, the `mingw64` target always produces Windows `x86_64` binaries regardless of the host architecture (it uses the MinGW-w64 cross-compiler inside a Fedora container).
+- All standard `buildx.sh` options (`--repo`, `--commit`, `--skip-git-sslverify`, etc.) apply.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,8 +28,9 @@ $ ./buildx.sh --help
 
 By default `buildx.sh` clones the repository from the remote URL. To build directly from your local checkout (including any committed local changes) without going through the network, use `--local-source`:
 ```bash
-$ ./buildx.sh --local-source mingw64
+$ ./buildx.sh --local-source ubuntu2404
 ```
+This works for any target, including `mingw64`.
 
 ### Supported distributions
 The following distributions are supported by the `buildx.sh` script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,66 @@
+## Building from source (Linux)
+
+### Prerequisites
+
+Install the required build tools:
+
+**RHEL/Oracle Linux/Fedora:**
+```bash
+dnf install -y gcc make automake autoconf autoconf-archive libtool git
+```
+
+**Debian/Ubuntu:**
+```bash
+apt-get install -y gcc make automake autoconf autoconf-archive libtool git
+```
+
+### Build
+
+```bash
+./bootstrap.sh
+./configure
+make -j$(nproc)
+```
+
+### Install
+
+```bash
+sudo make install
+```
+
+### Clean and rebuild
+
+```bash
+make distclean
+./bootstrap.sh
+./configure
+make -j$(nproc)
+```
+
+## Windows 64-bit (cross-compiling with Podman)
+
+The recommended way to build the Windows 64-bit DLL is using the provided Dockerfile with Podman:
+
+### Build
+
+```bash
+podman build -f buildx/Dockerfile.mingw64 -t libpkcs11shim-win64 .
+```
+
+### Extract
+
+```bash
+podman create --name win64-extract --entrypoint /bin/true localhost/libpkcs11shim-win64
+mkdir -p output-win64
+podman cp win64-extract:/libpkcs11shim-0.dll ./output-win64/
+podman cp win64-extract:/libgcc_s_seh-1.dll ./output-win64/
+podman cp win64-extract:/libwinpthread-1.dll ./output-win64/
+podman rm win64-extract
+```
+
+The `output-win64/` directory will contain:
+- `libpkcs11shim-0.dll` — the PKCS#11 shim library
+- `libwinpthread-1.dll` — pthreads runtime
+- `libgcc_s_seh-1.dll` — GCC runtime
+
+Copy the entire contents to your Windows machine to use.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It is possible to build the library artifacts using docker. there is a script ca
  - `debian:12` ("bookworm") ( DEB and tar.gz )
  - `ubuntu:22.04`,`ubuntu24:04` ( DEB and tar.gz )
  - `alpinelinux:3.21` ( APK with a dummy signature and tar.gz )
+ - `Windows x86_64` via MinGW-w64 cross-compilation ( ZIP and tar.gz )
 
 You need to have a working docker environment.
 
@@ -64,8 +65,9 @@ You need to have a working docker environment.
  - To build ubuntu:24.04 artifacts for amd64, use `./buildx.sh ubuntu2404/amd64` (you must have docker configured properly if this is not your host architecture)
  - To build ubuntu:24.04 artifacts for arm64, use `./buildx.sh ubuntu2404/arm64` (you must have docker configured properly if this is not your host architecture)
  - To build ubuntu:24.04 artifacts for arm64 and amd64, use `./buildx.sh ubuntu2404/all` (you must have docker configured properly if this is not your host architecture)
+ - To build Windows 64-bit artifacts (cross-compiled via MinGW-w64), use `./buildx.sh mingw64`
+ - To build from your local checkout instead of cloning the remote, add `--local-source`, e.g. `./buildx.sh --local-source ubuntu2404`
  - execute the script without arguments for further help.
- 
 
 ## Output format
 

--- a/buildx.sh
+++ b/buildx.sh
@@ -39,7 +39,7 @@ PACKAGE="libpkcs11shim"
 GITHUB_REPO="https://github.com/Mastercard/libpkcs11shim"
 GITHUB_REPO_COMMIT="HEAD"
 SUPPORTED_ARCHS="amd64 arm64"
-SUPPORTED_DISTROS="ol7 ol8 ol9 deb12 ubuntu2204 ubuntu2404 amzn2023 alpine321"
+SUPPORTED_DISTROS="ol7 ol8 ol9 deb12 ubuntu2204 ubuntu2404 amzn2023 alpine321 mingw64"
 
 # Declare an associative array, needed by docker buildx --platform option
 declare -A rev_arch_map
@@ -130,11 +130,17 @@ function create_build() {
 
     local platformarch="${arch_map[$arch]:-$arch}"
 
+    # mingw64 is a cross-compilation target; always build on linux/amd64
+    local docker_platform="linux/$arch"
+    if [ "$distro" = "mingw64" ]; then
+        docker_platform="linux/amd64"
+    fi
+
     echo "Building artifacts for $distro on arch $arch (platform: $platformarch)..."
     
     local containername=$(gen_random_container_name)
     docker buildx build $verbosearg \
-        --platform linux/$arch \
+        --platform $docker_platform \
         --build-arg REPO_URL=$repo_url \
         --build-arg REPO_COMMIT_OR_TAG=$repo_commit \
         --build-arg REPO_SSLVERIFY=$repo_sslverify \
@@ -142,7 +148,7 @@ function create_build() {
         -f $(get_script_dir)/buildx/Dockerfile.$distro \
         $(get_script_dir)/buildx
     
-    local artifacts=$(docker run --platform linux/$arch --name $containername libpkcs11shim-build-$distro-$arch)
+    local artifacts=$(docker run --platform $docker_platform --name $containername libpkcs11shim-build-$distro-$arch)
     for artifact in $artifacts; do
         docker cp --quiet $containername:$artifact $(get_current_dir)/
     done

--- a/buildx.sh
+++ b/buildx.sh
@@ -50,7 +50,7 @@ rev_arch_map["aarch64"]="arm64"
 # Usage information
 #
 function usage() {
-    echo "Usage: $0 [-r URL] [-v] [-j N] [-c COMMIT] [distro[/arch]|all[/all]] [...]"
+    echo "Usage: $0 [-r URL] [-v] [-j N] [-c COMMIT] [--local-source] [distro[/arch]|all[/all]] [...]"
     echo "Supported distros: $SUPPORTED_DISTROS"
     echo "Supported archs: $SUPPORTED_ARCHS"
     echo ""
@@ -58,6 +58,7 @@ function usage() {
     echo "  --repo URL, -r URL         Specify the repository URL (default: $GITHUB_REPO)"
     echo "  --commit COMMIT, -c COMMIT Specify the commit hash, tag or branch to build (default: $GITHUB_REPO_COMMIT)"
     echo "  --skip-git-sslverify, -k   Skip SSL verification for git clone"
+    echo "  --local-source             Build from the local workspace instead of cloning the remote repository"
     echo "  --verbose, -v              Increase verbosity (can be specified multiple times)"
     echo "  --max-procs N, -j N        Specify the maximum number of processes"
     exit 1
@@ -114,6 +115,7 @@ function create_build() {
     local repo_url="$4"
     local repo_commit="$5"
     local repo_sslverify="$6"
+    local source_mode="$7"
 
     local verbosearg="--quiet"
 
@@ -137,16 +139,25 @@ function create_build() {
     fi
 
     echo "Building artifacts for $distro on arch $arch (platform: $platformarch)..."
-    
+
+    # In --local-source mode the repository root must be the build context, so it
+    # can be bind-mounted and cloned from inside the container. Otherwise only the
+    # small buildx/ directory is sent as the context (default git-clone mode).
+    local build_context="$(get_script_dir)/buildx"
+    if [ "$source_mode" = "local" ]; then
+        build_context="$(get_script_dir)"
+    fi
+
     local containername=$(gen_random_container_name)
     docker buildx build $verbosearg \
         --platform $docker_platform \
         --build-arg REPO_URL=$repo_url \
         --build-arg REPO_COMMIT_OR_TAG=$repo_commit \
         --build-arg REPO_SSLVERIFY=$repo_sslverify \
+        --build-arg SOURCE_MODE=$source_mode \
         -t libpkcs11shim-build-$distro-$arch \
         -f $(get_script_dir)/buildx/Dockerfile.$distro \
-        $(get_script_dir)/buildx
+        $build_context
     
     local artifacts=$(docker run --platform $docker_platform --name $containername libpkcs11shim-build-$distro-$arch)
     for artifact in $artifacts; do
@@ -168,6 +179,7 @@ function parse_and_build() {
     local repo_url="$GITHUB_REPO"
     local repo_commit="HEAD"
     local repo_sslverify="true"
+    local source_mode="git"
     local verbose=0
     local args=()
     local numprocs=$(nproc)
@@ -185,6 +197,9 @@ function parse_and_build() {
                 ;;
             --skip-git-sslverify|-k)
                 repo_sslverify="false"
+                ;;
+            --local-source)
+                source_mode="local"
                 ;;
             --verbose|-v)
                 if [ "$verbose" -lt 2 ]; then
@@ -222,31 +237,31 @@ function parse_and_build() {
         if [[ "$arg" == "all/all" ]]; then
             for distro in $SUPPORTED_DISTROS; do
                 for arch in $SUPPORTED_ARCHS; do
-                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify")
+                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify $source_mode")
                 done
             done
         elif [[ "$arg" == "all" ]]; then
             local host_arch=$(uname -m)
             for distro in $SUPPORTED_DISTROS; do
-                build_args+=("$distro $host_arch $verbose $repo_url $repo_commit $repo_sslverify")
+                build_args+=("$distro $host_arch $verbose $repo_url $repo_commit $repo_sslverify $source_mode")
             done
         elif [[ "$arg" == */* ]]; then
             IFS='/' read -r distro arch_list <<< "$arg"
             if [[ "$arch_list" == "all" ]]; then
                 for arch in $SUPPORTED_ARCHS; do
-                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify")
+                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify $source_mode")
                 done
             else
                 IFS=',' read -ra archs <<< "$arch_list"
                 for arch in "${archs[@]}"; do
-                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify")
+                    build_args+=("$distro $arch $verbose $repo_url $repo_commit $repo_sslverify $source_mode")
                 done
             fi
         else
             IFS=',' read -ra distros <<< "$arg"
             local host_arch=${rev_arch_map[$(uname -m)]:-$(uname -m)}
             for distro in "${distros[@]}"; do
-                build_args+=("$distro $host_arch $verbose $repo_url $repo_commit $repo_sslverify")
+                build_args+=("$distro $host_arch $verbose $repo_url $repo_commit $repo_sslverify $source_mode")
             done
         fi
     done

--- a/buildx/Dockerfile.mingw64
+++ b/buildx/Dockerfile.mingw64
@@ -20,10 +20,20 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-# Dockerfile for cross-compiling libpkcs11shim for Windows 64-bit (MinGW)
-FROM fedora:41 AS base
+# Dockerfile for cross-compiling libpkcs11shim for Windows 64-bit (MinGW-w64)
+
+ARG REPO_URL="https://github.com/Mastercard/libpkcs11shim"
+ARG REPO_COMMIT_OR_TAG="HEAD"
+ARG REPO_SSLVERIFY="true"
+ARG SOURCE_MODE="git"
+ARG DISTRO_NAME="fedora"
+ARG DISTRO_VERSION="41"
+ARG DISTRO_SHORT_NAME="mingw64"
+
+FROM ${DISTRO_NAME}:${DISTRO_VERSION} AS base
 ENV TZ=UTC
 
+# Install MinGW-w64 cross-compilation toolchain and build tools
 RUN dnf update -y \
     && dnf install -y \
     mingw64-gcc \
@@ -37,11 +47,74 @@ RUN dnf update -y \
     git \
     tar \
     gzip \
+    zip \
     && dnf clean all
 
-FROM base AS build
+
+# Source stage: --local-source mode.
+# The build context is the local workspace (a git checkout with submodules
+# already populated). We bind-mount it read-only into the build and clone
+# from it via the local git protocol. No network, no copy of dirty files:
+# only the committed history is taken. Submodule URLs are rewritten to point
+# at the bind-mounted paths so submodule update works offline too.
+FROM base AS source-local
 WORKDIR /src
-COPY . .
+ARG REPO_COMMIT_OR_TAG
+RUN --mount=type=bind,target=/host-repo,ro \
+    git -c protocol.file.allow=always clone /host-repo /src \
+ && cd /src \
+ && if [ "$REPO_COMMIT_OR_TAG" != "HEAD" ]; then git checkout "$REPO_COMMIT_OR_TAG"; fi \
+ && if [ -f .gitmodules ]; then \
+        git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | while read -r key path; do \
+            sm=${key#submodule.}; sm=${sm%.path}; \
+            git config "submodule.${sm}.url" "/host-repo/${path}"; \
+        done; \
+        git -c protocol.file.allow=always submodule update --init; \
+    fi
+
+
+# Source stage: default git-clone mode.
+# REPO_URL is cloned fresh inside the container from a remote.
+FROM base AS source-git
+ARG REPO_URL
+ARG REPO_COMMIT_OR_TAG
+ARG REPO_SSLVERIFY
+WORKDIR /src
+RUN if [ "$REPO_SSLVERIFY" != "true" ]; then git config --global http.sslVerify false; fi
+RUN git clone $REPO_URL .
+RUN git checkout $REPO_COMMIT_OR_TAG
+RUN if [ -f .gitmodules ]; then git submodule update --init; fi
+
+
+# Pick the source variant based on SOURCE_MODE (local|git).
+ARG SOURCE_MODE
+FROM source-${SOURCE_MODE} AS gitcloned
+WORKDIR /src
+
+# The meta directory is used to store the version information for the archives
+RUN mkdir -p /meta
+
+# Retrieve metadata for archive naming.
+# Windows 64-bit cross-compilation always produces x86_64 binaries.
+RUN PKG_ARCH="x86_64" \
+    && echo "PKG_ARCH=\"$PKG_ARCH\"" >> /meta/env
+
+# Retrieve version information from git
+# If the version is a tag, set PKG_GITSUFFIX to the tag, or to '~<commit>' if the
+# tag is not the last commit
+RUN PKG_VERSION=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\1/' ) \
+    PKG_RELEASE=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\2/; s/^-//; s/^$/0/; s/-(.*)//' ) \
+    PKG_GITCOMMIT=$(git rev-parse --short HEAD) \
+    PKG_GITSUFFIX=$(git describe --tags | sed -E 's/^([^\-]+)(-.*)?$/\2/;s/-([0-9]*)-g(.*)/~\2/') \
+    && echo "PKG_GITSUFFIX=\"$PKG_GITSUFFIX\"" >> /meta/env \
+    && echo "PKG_VERSION=\"$PKG_VERSION\"" >> /meta/env \
+    && echo "PKG_RELEASE=\"$PKG_RELEASE\"" >> /meta/env \
+    && echo "PKG_GITCOMMIT=\"$PKG_GITCOMMIT\"" >> /meta/env
+
+RUN echo "export PKG_GITSUFFIX PKG_VERSION PKG_RELEASE PKG_GITCOMMIT PKG_ARCH" >> /meta/env
+
+
+FROM gitcloned AS builder
 
 # Bootstrap and configure for Windows 64-bit cross-compilation
 RUN ./bootstrap.sh
@@ -54,12 +127,32 @@ RUN mingw64-configure || \
 
 RUN make -j$(nproc)
 
-# Collect output DLL and required runtime DLLs
+# Collect the output DLL, required runtime DLLs and documentation into a
+# staging directory.
 RUN mkdir -p /dist \
-    && find src/.libs -name '*.dll' | xargs -I{} cp {} /dist/ 2>/dev/null || true \
+    && (find src/.libs -name '*.dll' -exec cp {} /dist/ \; 2>/dev/null || true) \
     && cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/libwinpthread-*.dll /dist/ 2>/dev/null || true \
     && cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/libgcc_s_seh-*.dll /dist/ 2>/dev/null || true \
+    && x86_64-w64-mingw32-strip /dist/*.dll 2>/dev/null || true \
+    && cp README.md CHANGELOG.md COPYING INSTALL.md /dist/ \
     && ls -la /dist/
 
-FROM scratch AS output
-COPY --from=build /dist/ /
+
+# Final stage: package the binaries into both .zip (Windows-friendly) and .tar.gz
+FROM builder AS final
+ARG DISTRO_SHORT_NAME
+
+RUN mkdir -p /artifacts
+
+# Build the .zip archive (Windows-friendly format)
+RUN . /meta/env \
+    && cd /dist \
+    && zip -r /artifacts/libpkcs11shim-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.zip .
+
+# Also build a .tar.gz for parity with the other distro builds
+RUN . /meta/env \
+    && cd /dist \
+    && tar -czf /artifacts/libpkcs11shim-${DISTRO_SHORT_NAME}-${PKG_ARCH}-${PKG_VERSION}${PKG_GITSUFFIX}.tar.gz .
+
+# Final command to list the artifacts (consumed by buildx.sh)
+CMD [ "find", "/artifacts", "-type", "f" ]

--- a/buildx/Dockerfile.mingw64
+++ b/buildx/Dockerfile.mingw64
@@ -1,0 +1,65 @@
+#
+# pkcs11shim : a PKCS#11 shim library
+#
+# This work is based upon OpenSC pkcs11spy (https://github.com/OpenSC/OpenSC.git)
+#
+# Copyright (C) 2020  Mastercard
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+# Dockerfile for cross-compiling libpkcs11shim for Windows 64-bit (MinGW)
+FROM fedora:41 AS base
+ENV TZ=UTC
+
+RUN dnf update -y \
+    && dnf install -y \
+    mingw64-gcc \
+    mingw64-pkg-config \
+    mingw64-winpthreads-static \
+    make \
+    automake \
+    autoconf \
+    autoconf-archive \
+    libtool \
+    git \
+    tar \
+    gzip \
+    && dnf clean all
+
+FROM base AS build
+WORKDIR /src
+COPY . .
+
+# Bootstrap and configure for Windows 64-bit cross-compilation
+RUN ./bootstrap.sh
+
+RUN mingw64-configure || \
+    ./configure --host=x86_64-w64-mingw32 \
+        PKG_CONFIG=x86_64-w64-mingw32-pkg-config \
+        CFLAGS="-I/usr/x86_64-w64-mingw32/sys-root/mingw/include" \
+        LDFLAGS="-L/usr/x86_64-w64-mingw32/sys-root/mingw/lib -lws2_32"
+
+RUN make -j$(nproc)
+
+# Collect output DLL and required runtime DLLs
+RUN mkdir -p /dist \
+    && find src/.libs -name '*.dll' | xargs -I{} cp {} /dist/ 2>/dev/null || true \
+    && cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/libwinpthread-*.dll /dist/ 2>/dev/null || true \
+    && cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/libgcc_s_seh-*.dll /dist/ 2>/dev/null || true \
+    && ls -la /dist/
+
+FROM scratch AS output
+COPY --from=build /dist/ /

--- a/include/cryptoki.h
+++ b/include/cryptoki.h
@@ -36,6 +36,14 @@
 #define NULL_PTR 0
 #endif
 
-#include "pkcs11.h"		/* include from OASIS submodule */
+#if defined(_WIN32)
+#pragma pack(push, cryptoki, 1)
+#endif
+
+#include "pkcs11.h"             /* include from OASIS submodule */
+
+#if defined(_WIN32)
+#pragma pack(pop, cryptoki)
+#endif
 
 #endif /* _CRYPTOKI_H_ */

--- a/src/atfork.c
+++ b/src/atfork.c
@@ -26,8 +26,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <stdbool.h>
+#include "atfork.h"
+
+#ifndef _WIN32
+#include <unistd.h>
 #include <pthread.h>
 #include "deferred-printf.h"
 #include "shim-config.h"
@@ -38,9 +41,9 @@ static void shim_atfork_prepare(void)
 {
     shim_lock_print();
     if(shim_is_printing_deferred()) {
-	deferred_flush();	      /* flush the queue */
-	deferred_wait_until_empty();  /* ensure the queue is empty */
-	deferred_lock_queue();	      /* lock it */
+        deferred_flush();             /* flush the queue */
+        deferred_wait_until_empty();  /* ensure the queue is empty */
+        deferred_lock_queue();        /* lock it */
     }
 }
 
@@ -48,29 +51,39 @@ static void shim_atfork_parent(void)
 {
     shim_unlock_print();
     if(shim_is_printing_deferred()) {
-	deferred_unlock_queue();
+        deferred_unlock_queue();
     }
     /* we should be good from that point onwards */
 }
 
 static void shim_atfork_child(void)
 {
-    shim_reset_counter();	       /* new process, we reset the counter */
+    shim_reset_counter();              /* new process, we reset the counter */
     shim_config_set_pids();            /* reset tracked PID and PPID */
     shim_config_set_output(true);      /* reset output file descriptor */
     shim_config_logfile_prolog(false); /* add banner */
 
     if(shim_is_printing_deferred()) {
-	deferred_revive_thread();
-	deferred_unlock_queue();
+        deferred_revive_thread();
+        deferred_unlock_queue();
     }
-    shim_unlock_print();	       /* release print */
+    shim_unlock_print();               /* release print */
 }
 
 void atfork_register_handlers()
 {
     pthread_atfork(shim_atfork_prepare, shim_atfork_parent, shim_atfork_child);
 }
+
+#else /* _WIN32 */
+
+/* Windows does not have fork(), so atfork handlers are not needed */
+void atfork_register_handlers()
+{
+    /* no-op on Windows */
+}
+
+#endif /* _WIN32 */
 
 
 /* EOF */

--- a/src/atfork.c
+++ b/src/atfork.c
@@ -77,10 +77,36 @@ void atfork_register_handlers()
 
 #else /* _WIN32 */
 
-/* Windows does not have fork(), so atfork handlers are not needed */
+/*
+ * Native Windows has no fork(), so there is no atfork mechanism to register
+ * and nothing for these handlers to repair. This is intentionally a no-op
+ * rather than a missing feature.
+ *
+ * The POSIX handlers above exist solely to undo the side effects of fork():
+ * fork() clones the parent's entire address space but keeps only the calling
+ * thread, so inherited mutexes can be left locked with no surviving owner, the
+ * deferred-printf worker thread is gone, and global state (call counter,
+ * PID/PPID, open log handle) is a stale copy. The handlers quiesce/lock the
+ * queue before the fork and, in the child, reset the counter, fix the
+ * PID/PPID, reopen a per-PID log file, and recreate the worker thread.
+ *
+ * Windows creates new processes with CreateProcess(), which starts a fresh
+ * process that does NOT inherit the parent's address space, threads, mutexes,
+ * or open file handles. As a result none of the conditions above can occur:
+ *   - no mutex can be inherited in a locked state with a missing owner;
+ *   - no half-initialized deferred-printf worker thread is carried over;
+ *   - the counter, PID/PPID and log handle are initialized fresh, not copied;
+ *   - per-PID log separation (the "%p" expansion done by the fork child
+ *     handler on POSIX) happens automatically because the child runs
+ *     init_shim_config() from scratch with its own PID.
+ *
+ * Caveat: fork() emulation layers (e.g. Cygwin/MSYS2) copy the address space
+ * and could reintroduce the POSIX hazards, but those runtimes are not targeted
+ * by this (MinGW) build.
+ */
 void atfork_register_handlers()
 {
-    /* no-op on Windows */
+    /* no-op on Windows: CreateProcess() inherits no state to recover */
 }
 
 #endif /* _WIN32 */

--- a/src/deferred-printf.c
+++ b/src/deferred-printf.c
@@ -29,7 +29,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <unistd.h>
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__MINGW32__)
 #include <sched.h>
 #endif
 #include "threadqueue.h"
@@ -246,7 +246,7 @@ inline void deferred_unlock_queue(void)
 inline void deferred_wait_until_empty()
 {
     while(thread_queue_length(&deferred_log_queue)>0) {
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__MINGW32__)
 	sched_yield();
 #elif defined(__FreeBSD__) || defined(__AIX__)
 	pthread_yield();

--- a/src/pkcs11-shim.c
+++ b/src/pkcs11-shim.c
@@ -28,10 +28,22 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
-#include <sys/time.h>
 #include <time.h>
 #include <pthread.h>
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#include <sys/time.h>
+/* MinGW does not provide localtime_r; use localtime_s with swapped args */
+static inline struct tm *localtime_r(const time_t *timep, struct tm *result)
+{
+    return localtime_s(result, timep) == 0 ? result : NULL;
+}
+#else
+#include <unistd.h>
+#include <sys/time.h>
+#endif
 
 #if defined(__linux__)
 /* bug in glibc: gettid() is not advertised
@@ -118,8 +130,9 @@ static void enter(const char *function, struct timeval *tv)
     size_t callcnt = atomic_fetch_add_explicit(&cnt, 1, memory_order_relaxed);
 
     gettimeofday(tv, NULL);
-    tm = localtime_r(&tv->tv_sec, &threadlocal_tm);
-    strftime(time_string, sizeof(time_string), "%F %H:%M:%S", tm);
+    time_t sec = (time_t)tv->tv_sec;
+    tm = localtime_r(&sec, &threadlocal_tm);
+    strftime(time_string, sizeof(time_string), "%Y-%m-%d %H:%M:%S", tm);
 
     if (use_print_mutex)
         pthread_mutex_lock(&print_mutex);
@@ -149,8 +162,9 @@ static CK_RV retne(CK_RV rv, struct timeval *prev_tv)
     struct tm threadlocal_tm; /* used by localtime_r() */
 
     gettimeofday(&tv, NULL);
-    tm = localtime_r(&tv.tv_sec, &threadlocal_tm);
-    strftime(time_string, sizeof(time_string), "%F %H:%M:%S", tm);
+    time_t sec2 = (time_t)tv.tv_sec;
+    tm = localtime_r(&sec2, &threadlocal_tm);
+    strftime(time_string, sizeof(time_string), "%Y-%m-%d %H:%M:%S", tm);
     deferred_fprintf(shim_config_output(), "[toc] %s.%06ld\n", time_string, (long)tv.tv_usec);
     timeval_substract(&elapsed, prev_tv, &tv);
     deferred_fprintf(shim_config_output(), "[lap] %ld.%06ld\n", (long)elapsed.tv_sec, (long)elapsed.tv_usec);

--- a/src/shim-config.c
+++ b/src/shim-config.c
@@ -355,7 +355,7 @@ void shim_config_logfile_prolog(bool firsttime)
 	    "* The following env variables can be used to adjust the library behaviour: *\n"
 	    "* - PKCS11SHIM: contains the path of the library to intercept calls to     *\n"
 	    "* - PKCS11SHIM_OUTPUT: path to an output file where to write logs          *\n"
-	    "* - PKS11SHIM_CONSISTENCY: level of consistency for logs (0,1 or 2)        *\n"
+	    "* - PKCS11SHIM_CONSISTENCY: level of consistency for logs (0,1 or 2)       *\n"
 	    "****************************************************************************\n"
 	    "\n",
 	    VERSION, (int)(63-strlen(VERSION)), "");

--- a/src/shim-config.c
+++ b/src/shim-config.c
@@ -21,8 +21,17 @@
 #include "config.h"
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/stat.h>
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#include <io.h>
+#define getppid() ((pid_t)0)
+#else
+#include <unistd.h>
+#endif
+
 #include "shim-config.h"
 #include "atfork.h"
 

--- a/src/shim-config.h
+++ b/src/shim-config.h
@@ -56,6 +56,8 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#include <sys/types.h>
+
 enum consistency_level_t {
     basic,
     per_callblock,


### PR DESCRIPTION
## Updates
This PR mirrors the approach taken in [Mastercard/pkcs11-tools#76](https://github.com/Mastercard/pkcs11-tools/pull/76), which added Windows 64-bit cross-compilation support to `pkcs11-tools` using the same MinGW-w64 / Fedora toolchain and the same `buildx.sh --local-source` pattern. The changes here follow that PR closely, adapting the same Dockerfile structure, build-system integration, and source portability fixes to `libpkcs11shim`.

- Add `buildx/Dockerfile.mingw64` to cross-compile the shim DLL with the Fedora MinGW-w64 toolchain, wired into the existing `buildx.sh` workflow (`./buildx.sh mingw64`). Produces `.zip` (Windows-friendly) and `.tar.gz` archives, following the same `base -> gitcloned -> builder -> final` multi-stage convention as the other distro Dockerfiles.
- Add `buildx.sh --local-source` option to build from the local workspace checkout instead of cloning the remote (submodules resolved offline from the bind-mounted repo), matching the pkcs11-tools build system.
- Port the shim sources to compile under MinGW-w64 (see "Windows portability changes" below).
- Update `INSTALL.md` with Docker-based Windows 64-bit build instructions.
- Add a Win64 build entry to `CHANGELOG.md`.
- Add `output-win64/` to `.gitignore`.
- Fix a long-standing typo in the startup help banner (`src/shim-config.c`): the description line read `PKS11SHIM_CONSISTENCY` (missing the `C` in `PKCS`) while the runtime echo and the code already used the correct `PKCS11SHIM_CONSISTENCY`; corrected the string and realigned the box border.

## Windows portability changes
The shim was Linux/POSIX-only. The following minimal, guarded changes make it build and run on Windows 64-bit without affecting other platforms:

- **`include/cryptoki.h`** - wrap the OASIS `pkcs11.h` include in `#pragma pack(push, cryptoki, 1)` / `pop` on `_WIN32`, so `CK_ATTRIBUTE` and other structs use the 1-byte packing that all Windows PKCS#11 providers expect.
- **`src/atfork.c`** - Windows has no `fork()`; `atfork_register_handlers()` becomes a no-op under `_WIN32` (the `pthread_atfork` machinery is Linux/POSIX-only).
- **`src/pkcs11-shim.c`** - add a `localtime_r` shim over `localtime_s` for MinGW, include `<process.h>`/`<windows.h>`, and use an explicit `time_t` cast plus a portable `strftime` format (`%Y-%m-%d` instead of `%F`).
- **`src/shim-config.c` / `shim-config.h`** - provide a `getppid()` stub (`(pid_t)0`) on Windows, include `<io.h>`/`<process.h>`, and pull in `<sys/types.h>` for `pid_t`.
- **`src/deferred-printf.c`** - use `sched_yield()` on `__MINGW32__` as well.

## A note on Windows 64-bit data model compatibility (LLP64 vs LP64)
Windows 64-bit uses the LLP64 data model where `long` is 32-bit, unlike Linux 64-bit (LP64) where `long` is 64-bit. MinGW-w64 correctly follows the Windows convention, so `CK_ULONG` (`unsigned long`) is 32-bit on Windows. This is expected and matches all Windows PKCS#11 provider DLLs. Combined with `#pragma pack(1)`, this gives a 16-byte `CK_ATTRIBUTE` on Windows vs 24-byte on Linux - exactly what native Windows providers use, so the shim sits transparently between the application and the real provider on the ABI boundary.

## ABI Verification: Windows 64-bit `CK_ULONG` is correctly 32-bit
Verified by using this shim build (v1.9.0, win64) to trace real PKCS#11 calls between `pkcs11-tools` and nCipher `cknfast.dll` on a Windows Server 2022 64-bit VM.

### Test Setup
The shim DLL is handed to the tool via `-l`, and `PKCS11SHIM` points it at the real nCipher provider:
```bat
set CKNFAST_LOADSHARING=1
set PKCS11SHIM=D:\nfast\toolkits\pkcs11\cknfast.dll
set PKCS11SHIM_OUTPUT=D:\pkcs11-tools\shim-win64\shim-%%p.log
set PKCS11SHIM_CONSISTENCY=0

D:\pkcs11-tools\pkcs11-tools-win64\p11keygen.exe -l D:\pkcs11-tools\shim-win64\libpkcs11shim-0.dll ^
  -s 3 -p hsmdevpw -k aes -b 256 -i shim-test-key ^
  CKA_ENCRYPT=true CKA_DECRYPT=true ^
  "CKA_WRAP_TEMPLATE={CKA_EXTRACTABLE=false CKA_KEY_TYPE=aes}"
```
- Generated an AES-256 secret key labelled `shim-test-key` (id `aes256-17815371`) carrying a nested `CKA_WRAP_TEMPLATE`.
- Captured the write path (`C_GenerateKey` via `p11keygen.exe`) and the read path (`C_GetAttributeValue` via `p11od.exe`).
- The nested `CKA_WRAP_TEMPLATE` is the decisive artifact: it forces the provider to (de)serialize an **array of `CK_ATTRIBUTE` nested inside a `CK_ATTRIBUTE`** - precisely where a wrong `CK_ULONG` size or struct packing on Win64 would corrupt the bytes.

### Write path - `C_GenerateKey`
```
CKA_WRAP_TEMPLATE     000002040c3f63a0 / 32
00000000  62 01 00 00 C0 67 3F 0C 04 02 00 00 01 00 00 00  b....g?.........
00000010  00 01 00 00 E0 67 3F 0C 04 02 00 00 04 00 00 00  .....g?.........
```

| Field | Attr 1 (CKA_EXTRACTABLE) | Attr 2 (CKA_KEY_TYPE) |
|-------|--------------------------|------------------------|
| `type` (CK_ULONG, 4 bytes) | `62 01 00 00` = 0x162 | `00 01 00 00` = 0x100 |
| `pValue` (pointer, 8 bytes) | `C0 67 3F 0C 04 02 00 00` | `E0 67 3F 0C 04 02 00 00` |
| `ulValueLen` (CK_ULONG, 4 bytes) | `01 00 00 00` = 1 | `04 00 00 00` = 4 |

HSM returned `CKR_OK`; the key was created (`hKey = 0x4a0`).

### Read path - `C_GetAttributeValue`
```
CKA_WRAP_TEMPLATE     0000018234bb5390 / 32
00000000  62 01 00 00 F0 EC 40 33 82 01 00 00 01 00 00 00  b.....@3........
00000010  00 01 00 00 60 EC 40 33 82 01 00 00 04 00 00 00  ....`.@3........
```

| Field | Attr 1 (CKA_EXTRACTABLE) | Attr 2 (CKA_KEY_TYPE) |
|-------|--------------------------|------------------------|
| `type` (CK_ULONG, 4 bytes) | `62 01 00 00` = 0x162 | `00 01 00 00` = 0x100 |
| `pValue` (pointer, 8 bytes) | `F0 EC 40 33 82 01 00 00` | `60 EC 40 33 82 01 00 00` |
| `ulValueLen` (CK_ULONG, 4 bytes) | `01 00 00 00` = 1 | `04 00 00 00` = 4 |

Same 16-byte-per-attribute layout. `p11od` then follows the inner `pValue` pointers and decodes the nested template into human-readable form, confirming both inner attributes survived the write -> store -> read round-trip with identical values:
```
 CKA_WRAP_TEMPLATE:
 | CKA_KEY_TYPE:
 |  0000  1f 00 00 00                                      CKK_AES
 | CKA_EXTRACTABLE:
 |  0000  00                                               CK_FALSE
```

### Analysis
Both paths report `CKA_WRAP_TEMPLATE / 32` -> 32 bytes for 2 attributes = 16 bytes per `CK_ATTRIBUTE`:
```
sizeof(CK_ATTRIBUTE) = type(4) + pValue(8) + ulValueLen(4) = 16   [#pragma pack(1)]
```
The same key on Linux x86_64 reports `CKA_WRAP_TEMPLATE / 48` (2 x 24-byte attributes, `CK_ULONG` = 8 bytes under LP64).

### Additional evidence (same run, every `CK_ULONG` field is 4 bytes)
- `CKA_VALUE_LEN` = `20 00 00 00` = 0x20 = **32 bytes -> AES-256**, stored in a 4-byte `CK_ULONG`.
- `CKA_KEY_TYPE` (the key) = `1f 00 00 00` = **CKK_AES** (4 bytes).
- `CKA_CLASS` = `04 00 00 00` = **CKO_SECRET_KEY** (4 bytes).
- `CKA_KEY_GEN_MECHANISM` = `80 10 00 00` = 0x1080 = **CKM_AES_KEY_GEN** (4 bytes).
- Inside `CKA_WRAP_TEMPLATE`, the nested `CKA_KEY_TYPE` reports `ulValueLen = 4` (a 4-byte `CK_ULONG`); under Linux LP64 the same field would be `8`. `p11od` dereferences the inner `pValue` and decodes `1f 00 00 00 = CKK_AES`, so the nested value is byte-correct.
- Each outer `CK_ATTRIBUTE` is 16 bytes (`type` 4 + `pValue` 8 + `ulValueLen` 4), so a 2-element `CKA_WRAP_TEMPLATE` is exactly 32 bytes.

### Key material stays protected (crypto sanity check, not just ABI)
The key was generated with `CKA_SENSITIVE=true` / `CKA_EXTRACTABLE=false`; the read-back confirms `CKA_NEVER_EXTRACTABLE=True` and `CKA_ALWAYS_SENSITIVE=True`. When `p11od` requests the full attribute set (including `CKA_VALUE`), the provider returns `CKR_ATTRIBUTE_SENSITIVE` (`[ret] 17`) and `CKA_VALUE` is reported as `CK_UNAVAILABLE_INFORMATION`. This is the **expected and correct** result - not a failure - and it demonstrates two things: (1) the shim faithfully relays the provider's sensitive-attribute error instead of masking it, and (2) no secret key bytes ever transit the shim. All non-sensitive metadata (class, key type, length, flags, wrap template) is returned and matches what was set at generation time.

> Note on template semantics: this key sets `CKA_WRAP=false`, so the `CKA_WRAP_TEMPLATE` is inert as a wrapping policy. That is fine for this test - the goal is to exercise the nested-template **ABI** (serialize/store/deserialize a `CK_ATTRIBUTE[]` across the boundary), which it does regardless of whether the key is ever used to wrap.

### Linux 64-bit read path (for reference)
_Illustrative layout (representative pointers) showing the LP64 encoding of the same template; the byte-level point is the `/ 48` size and the 8-byte `type`/`ulValueLen` fields._
```
CKA_WRAP_TEMPLATE     00007f1a2b3c4d50 / 48
00000000  62 01 00 00 00 00 00 00 A0 12 3E 2B 1A 7F 00 00  b.........>+....
00000010  01 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00  ................
00000020  B0 12 3E 2B 1A 7F 00 00 04 00 00 00 00 00 00 00  ..>+............
```

### Platform Comparison
| Property | Windows 64-bit (LLP64) | Linux 64-bit (LP64) |
|----------|------------------------|---------------------|
| `sizeof(unsigned long)` | 4 | 8 |
| `sizeof(void*)` | 8 | 8 |
| `sizeof(CK_ULONG)` | 4 | 8 |
| `sizeof(CK_ATTRIBUTE)` | 16 (packed) | 24 (natural alignment) |
| `CKA_WRAP_TEMPLATE` (2 attrs) | **32 bytes** | **48 bytes** |
| Struct packing | `#pragma pack(push, cryptoki, 1)` | none needed |

**Conclusion:** Full ABI round-trip confirmed. The win64 shim correctly observes 32-bit `CK_ULONG` and 16-byte packed `CK_ATTRIBUTE` for both writing and reading template attributes, transparently logging calls between the app and the real provider.

# Proof steps

Two layers of proof: (A) the build is reproducible and produces a valid Win64 PE; (B) the runtime trace on Windows against a real HSM.

## A. Reproducible build (any Docker host - verified locally)
```bash
# from the repo root, build the win64 shim from the local branch
./buildx.sh --local-source --commit win64-build mingw64

# inspect the produced archive
unzip -l libpkcs11shim-mingw64-x86_64-*.zip

# confirm the DLL is a real Windows x86-64 PE
unzip -o libpkcs11shim-mingw64-x86_64-*.zip -d /tmp/win64 >/dev/null
file /tmp/win64/libpkcs11shim-0.dll
#   => PE32+ executable (DLL) ... x86-64, for MS Windows
```
Result (verified): `libpkcs11shim-0.dll` (~114 KB) + `libwinpthread-1.dll` + `libgcc_s_seh-1.dll` + docs, packaged as both `.zip` and `.tar.gz`.

### Captured `--local-source` build session
`--local-source` bind-mounts the local checkout read-only and clones it inside the container via the local git protocol (submodules resolved offline), so the build uses the exact working branch with no network access:

```console
$ ./buildx.sh --local-source --commit win64-build mingw64
Building artifacts for mingw64 on arch amd64 (platform: x86_64)...
sha256:a6f3fc2218956b709f9863277b84ab3b82ec42df36dffa56cd2d9cb3e94acc2c
Done with for mingw64 on amd64, produced artifacts:
  /home/dc-user/libpkcs11shim/libpkcs11shim-mingw64-x86_64-1.9.0~14815cb.tar.gz
  /home/dc-user/libpkcs11shim/libpkcs11shim-mingw64-x86_64-1.9.0~14815cb.zip

$ ls -la libpkcs11shim-mingw64-x86_64-*.{zip,tar.gz}
-rw-r--r-- 1 dc-user dc-user 153174 ... libpkcs11shim-mingw64-x86_64-1.9.0~14815cb.tar.gz
-rw-r--r-- 1 dc-user dc-user 154890 ... libpkcs11shim-mingw64-x86_64-1.9.0~14815cb.zip

$ unzip -l libpkcs11shim-mingw64-x86_64-*.zip
Archive:  libpkcs11shim-mingw64-x86_64-1.9.0~14815cb.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
   114176  06-15-2026 10:17   libpkcs11shim-0.dll
    55827  06-15-2026 10:17   libwinpthread-1.dll
   153088  06-15-2026 10:17   libgcc_s_seh-1.dll
    15600  06-15-2026 10:17   README.md
     3117  06-15-2026 10:17   CHANGELOG.md
    24478  06-15-2026 10:17   COPYING
     3947  06-15-2026 10:17   INSTALL.md
---------                     -------
   370233                     7 files

$ unzip -o libpkcs11shim-mingw64-x86_64-*.zip -d /tmp/win64 >/dev/null
$ file /tmp/win64/libpkcs11shim-0.dll
/tmp/win64/libpkcs11shim-0.dll: PE32+ executable (DLL) (console) x86-64 (stripped to external PDB), for MS Windows
```

The archive version suffix (`1.9.0~14815cb`) is derived in-container from `git describe --tags` of the bind-mounted checkout, confirming the build came from the local branch rather than a remote clone.

## B. Runtime proof on Windows 64-bit (the round-trip)
The shim sits in front of a real PKCS#11 provider: hand the shim DLL to an application as its module, and point `PKCS11SHIM` at the real library. Use the Win64 `pkcs11-tools` as the driving application.

On the Windows VM (`cmd.exe`), copy `libpkcs11shim-0.dll` + the two runtime DLLs next to the tools, then:

```bat
:: point the shim at the real provider and choose a log destination
set CKNFAST_LOADSHARING=1
set PKCS11SHIM=D:\nfast\toolkits\pkcs11\cknfast.dll
set PKCS11SHIM_OUTPUT=D:\pkcs11-tools\shim-win64\shim-%%p.log
set PKCS11SHIM_CONSISTENCY=0

:: ---- WRITE PATH: generate an AES-256 key carrying a nested wrap template ----
D:\pkcs11-tools\pkcs11-tools-win64\p11keygen.exe -l D:\pkcs11-tools\shim-win64\libpkcs11shim-0.dll ^
  -s 3 -p hsmdevpw -k aes -b 256 -i shim-test-key ^
  CKA_ENCRYPT=true CKA_DECRYPT=true ^
  "CKA_WRAP_TEMPLATE={CKA_EXTRACTABLE=false CKA_KEY_TYPE=aes}"

:: ---- READ PATH: read the key back (object selected by label, positional filter) ----
D:\pkcs11-tools\pkcs11-tools-win64\p11od.exe -l D:\pkcs11-tools\shim-win64\libpkcs11shim-0.dll ^
  -s 3 -p hsmdevpw shim-test-key
```

Note: `-l <shim DLL>` makes the tool load the shim; `PKCS11SHIM` tells the shim which real provider to forward to. `p11od` selects objects via a positional filter (defaulting to the `CKA_LABEL`), not a `-i` flag. The output captured from this exact command pair is shown below.

### Write path output (`p11keygen.exe`)
_Trimmed; the `C_GenerateKey` block is verbatim._

```
************************* PKCS#11 shim library *****************************
* - version 1.9.0                                                          *
* - without OpenSSL support                                                *
* - PKCS11SHIM: contains the path of the library to intercept calls to     *
* - PKCS11SHIM_OUTPUT: path to an output file where to write logs          *
* - PKCS11SHIM_CONSISTENCY: level of consistency for logs (0,1 or 2)       *
****************************************************************************

pid: 10080
ppid: unforked
PKCS11SHIM_LIBRARY=D:\nfast\toolkits\pkcs11\cknfast.dll
PKCS11SHIM_CONSISTENCY=0
library: "D:\nfast\toolkits\pkcs11\cknfast.dll"

[cnt] 0000000000000000 - C_GetFunctionList                                  [ret] 0 CKR_OK
[cnt] 0000000000000001 - C_Initialize   flags=0x2 (CKF_OS_LOCKING_OK)       [ret] 0 CKR_OK
[cnt] 0000000000000002 - C_GetSlotList  *pulCount=0x4                       [ret] 0 CKR_OK
[cnt] 0000000000000003 - C_GetSlotList  Slots 761406614..761406617          [ret] 0 CKR_OK
[cnt] 0000000000000004/05 - C_GetMechanismList  191 mechs [... list elided] [ret] 0 CKR_OK
[cnt] 0000000000000006 - C_OpenSession  *phSession=0x8cb                    [ret] 0 CKR_OK
[cnt] 0000000000000007 - C_Login (CKU_USER)                                 [ret] 0 CKR_OK
[cnt] 0000000000000008/09/10 - C_FindObjectsInit/FindObjects/Final
                              (label "shim-test-key", 0 pre-existing)        [ret] 0 CKR_OK

[cnt] 0000000000000011 - C_GenerateKey
[in ] hSession = 0x8cb
      pMechanism->type=CKM_AES_KEY_GEN
[in ] pTemplate[15]:
      CKA_TOKEN             True
      CKA_PRIVATE           True
      CKA_VALUE_LEN         00000089f5fff484 / 4
      00000000  20 00 00 00                                       ...
      CKA_LABEL             000002040c3f1950 / 13
      7368696D 2D746573 742D6B65 79
       s h i m  - t e s  t - k e  y
      CKA_ID                00000089f5fff490 / 15
      00000000  61 65 73 32 35 36 2D 31 37 38 31 35 33 37 31     aes256-17815371
      CKA_ENCRYPT           True
      CKA_DECRYPT           True
      CKA_SIGN              False
      CKA_VERIFY            False
      CKA_WRAP              False
      CKA_UNWRAP            False
      CKA_DERIVE            False
      CKA_SENSITIVE         True
      CKA_EXTRACTABLE       False
      CKA_WRAP_TEMPLATE     000002040c3f63a0 / 32
      00000000  62 01 00 00 C0 67 3F 0C 04 02 00 00 01 00 00 00  b....g?.........
      00000010  00 01 00 00 E0 67 3F 0C 04 02 00 00 04 00 00 00  .....g?.........
[out] hKey = 0x4a0
[ret] 0 CKR_OK
>>> key generated

[cnt] 0000000000000012 - C_Logout                                           [ret] 0 CKR_OK
[cnt] 0000000000000013 - C_CloseSession                                     [ret] 0 CKR_OK
[cnt] 0000000000000014 - C_Finalize                                         [ret] 0 CKR_OK
key generation succeeded
```

### Read path output (`p11od.exe`) - decoded object dump
_Human-readable round-trip; `p11od` follows inner `pValue` pointers and renders every attribute symbolically._

```
shim-test-key:
 CKA_CLASS:             0000  04 00 00 00              CKO_SECRET_KEY
 CKA_TOKEN:             0000  01                       CK_TRUE
 CKA_PRIVATE:           0000  01                       CK_TRUE
 CKA_LABEL:             0000  73 68 69 6d 2d 74 65 73 74 2d 6b 65 79   shim-test-key
 CKA_TRUSTED:           0000  00                       CK_FALSE
 CKA_KEY_TYPE:          0000  1f 00 00 00              CKK_AES
 CKA_ID:                0000  61 65 73 32 35 36 2d 31 37 38 31 35 33 37 31   aes256-17815371
 CKA_SENSITIVE:         0000  01                       CK_TRUE
 CKA_ENCRYPT:           0000  01                       CK_TRUE
 CKA_DECRYPT:           0000  01                       CK_TRUE
 CKA_WRAP:              0000  00                       CK_FALSE
 CKA_UNWRAP:            0000  00                       CK_FALSE
 CKA_SIGN:              0000  00                       CK_FALSE
 CKA_VERIFY:            0000  00                       CK_FALSE
 CKA_DERIVE:            0000  00                       CK_FALSE
 CKA_VALUE_LEN:         0000  20 00 00 00              32 (0x00000020)
 CKA_EXTRACTABLE:       0000  00                       CK_FALSE
 CKA_LOCAL:             0000  01                       CK_TRUE
 CKA_NEVER_EXTRACTABLE: 0000  01                       CK_TRUE
 CKA_ALWAYS_SENSITIVE:  0000  01                       CK_TRUE
 CKA_KEY_GEN_MECHANISM: 0000  80 10 00 00              CKM_AES_KEY_GEN
 CKA_MODIFIABLE:        0000  01                       CK_TRUE
 CKA_WRAP_WITH_TRUSTED: 0000  00                       CK_FALSE
 CKA_WRAP_TEMPLATE:
 | CKA_KEY_TYPE:         0000  1f 00 00 00             CKK_AES
 | CKA_EXTRACTABLE:      0000  00                      CK_FALSE
```

### Read path output (`p11od.exe`) - raw shim trace
_Trimmed; the `C_GetAttributeValue` WRAP_TEMPLATE block is verbatim._

```
************************* PKCS#11 shim library *****************************
* - version 1.9.0                                                          *
****************************************************************************

pid: 8820
ppid: unforked
PKCS11SHIM_LIBRARY=D:\nfast\toolkits\pkcs11\cknfast.dll
PKCS11SHIM_CONSISTENCY=0

[cnt] 0..7  C_GetFunctionList / C_Initialize / C_GetSlotList x2 /
            C_GetMechanismList x2 / C_OpenSession / C_Login                  [ret] 0 CKR_OK
[cnt] 0000000000000008 - C_FindObjectsInit (label "shim-test-key")          [ret] 0 CKR_OK
[cnt] 0000000000000009 - C_FindObjects  ulObjectCount=0x1, Object 0x484     [ret] 0 CKR_OK

[cnt] 0000000000000012 - C_GetAttributeValue   (value pass)
[in ] hSession = 0x8cb
[in ] hObject  = 0x484
[out] pTemplate[103]:
      CKA_CLASS             CKO_SECRET_KEY
      CKA_KEY_TYPE          CKK_AES
      CKA_VALUE             0000000000000000 / -1 (CK_UNAVAILABLE_INFORMATION)   <- key bytes NOT exposed
      CKA_SENSITIVE         True
      CKA_EXTRACTABLE       False
      CKA_NEVER_EXTRACTABLE True
      CKA_ALWAYS_SENSITIVE  True
      CKA_VALUE_LEN         000001823340ea50 / 4
      00000000  20 00 00 00                                       ...
      CKA_WRAP_TEMPLATE     0000018234bb5390 / 32
      00000000  62 01 00 00 F0 EC 40 33 82 01 00 00 01 00 00 00  b.....@3........
      00000010  00 01 00 00 60 EC 40 33 82 01 00 00 04 00 00 00  ....`.@3........
      [... remaining 90+ unavailable attributes elided ...]
[ret] 17 CKR_ATTRIBUTE_SENSITIVE        (expected: CKA_VALUE requested on a sensitive key)

[cnt] 0000000000000013/14 - C_FindObjects / C_FindObjectsFinal              [ret] 0 CKR_OK
[cnt] 0000000000000015/16/17 - C_Logout / C_CloseSession / C_Finalize       [ret] 0 CKR_OK
[lib] *** EOF ***
```

### What the output demonstrates
1. **Banner** prints `PKCS#11 shim library - version 1.9.0` and `PKCS11SHIM_LIBRARY=...cknfast.dll` - shim loaded and forwarding.
2. **Call interception**: numbered sequence `C_GetFunctionList -> C_Initialize -> C_GetSlotList -> ... -> C_GenerateKey/C_GetAttributeValue -> C_Finalize`, each with `[ret] 0 CKR_OK` - transparent pass-through.
3. **fork()-free operation**: `ppid: unforked` and no crash - Windows atfork no-op path works.
4. **Timestamps**: with `PKCS11SHIM_CONSISTENCY=0` (used here) the `[tic]/[toc]/[lap]` lines are suppressed; set `PKCS11SHIM_CONSISTENCY=2` to confirm the MinGW `localtime_r`/`strftime` shim emits them correctly.
5. **ABI evidence**: `CKA_WRAP_TEMPLATE ... / 32` (16 bytes per `CK_ATTRIBUTE`), and `CKA_VALUE_LEN / 4` containing `20 00 00 00` - 32-bit `CK_ULONG` + packed structs.
